### PR TITLE
Update to build multi-platform image (amd64, arm64) 

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -49,17 +49,20 @@ jobs:
         id: get_version
         run: echo ::set-output name=VERSION::$(jq -r '.version' package.json)
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+        uses: docker/setup-buildx-action@v3
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -69,19 +72,18 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             ${{ steps.get_version.outputs.VERSION }}
             latest
 
-
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
@@ -89,3 +91,4 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ https://v2.ko.vuejs.org/v2/cookbook/dockerize-vuejs-app.html
 ### Cheat sheet
 https://docs.docker.com/get-started/docker_cheatsheet.pdf
 
+### Multi Arch Build (arm64, amd64)
+https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/
+
 ### customized command lines
 ```
 $PROJECT_BASE_DIR/bin/build.sh 1.2.3


### PR DESCRIPTION
Update docker-publish.yaml to build multi-platform image (amd64, arm64) 

(https://docs.docker.com/build/ci/github-actions/multi-platform/)